### PR TITLE
Create Github Issue and Pull Request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+Check your title. Try to make it short but descriptive. Have a quick look at the available [labels](https://github.com/TeamPorcupine/ProjectPorcupine/labels). If one seems relevant prefix the title with [label name].
+
+NOTE: This template is not enforced. You are encouraged to include all of the detail below, but if anything doesn't fit this particular issue feel free to delete it!
+
+### Expected behavior
+
+Should do X
+
+### Actual behavior
+
+Instead does Y
+
+```
+include error messages or stack trace if there are any exceptions
+```
+
+### Steps to reproduce the behavior
+
+- Step 1: do foo
+- Step 2: do bar
+- Step 3: do baz
+
+### Related issues / pull requests
+
+Reference #numbers here
+
+### Specs
+
+Any relevant system / version information. Include the output of running `git describe --tags` on the local repository you are testing against.
+
+Pings: @mentions (Note: all project maintainers are automatically notified of new issues. Only ping one if it is specifically relevant to them.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+First check your title. If this pull request has incomplete or unstable code prefix the title with [WIP]. Often people will give you feedback anyway, but if you are specifically requesting feedback prefix [Feedback Requested] to the title.
+
+NOTE: This template is not enforced. You are encouraged to include all of the detail below, but if anything doesn't fit this particular pull request feel free to delete it!
+
+### The issue this fixes
+
+Briefly describe the issue(s) addressed by this pull request. If there are any relevant issues or pull requests on Github reference their #numbers here.
+
+Fixes # 
+Closes # 
+
+### What this PR does
+
+Describe _how_ you have fixed the issue(s).
+If there are any UI or sprite changes, please include an image showing the new element(s).
+Please ensure that you have the proper permission to include any copyrighted art or sound assets under license terms compatible with the open source licensing of this project.
+
+## TODO (if this is a [WIP] PR)
+
+- [ ] foo
+- [ ] bar
+- [ ] baz
+
+Pings: @mentions (Note: all project maintainers are automatically notified of new pull requests. Only ping one if it is specifically relevant to them.)


### PR DESCRIPTION
# **This is just to test that the templates work on my own repo. CLOBBER THE CHANGES ON MASTER WHEN DONE!!!!!!!**

These templates are automatically filled in the editor textarea when
someone creates an Issue or Pull request on Github.
The text can be changed or deleted at will by the user, it is there merely
to serve as a prompt to include the pertinent information and format it in
a useful way.